### PR TITLE
ER-346: Fixed identifier lists

### DIFF
--- a/ereol_app_feeds/src/Helper/NodeHelper.php
+++ b/ereol_app_feeds/src/Helper/NodeHelper.php
@@ -75,10 +75,13 @@ class NodeHelper {
 
   /**
    * Get ting identifiers.
+   *
+   * @return string[]
+   *   A list of identifiers.
    */
   public function getTingIdentifiers($entity, $field_name) {
     if (!isset($entity->{$field_name}[LANGUAGE_NONE])) {
-      return NULL;
+      return [];
     }
 
     $relations = $this->getFieldValue($entity, $field_name, 'value', TRUE);


### PR DESCRIPTION
The app doesn't handle identifier lists being `null`. This fixes the identifier lists in the `themes` app feed to use empty lists rather than `null`.