### PR TITLE
ER-1083: Hid page tabs on user pages

### DIFF
--- a/ereol_frontend/ereol_frontend.pages_default.inc
+++ b/ereol_frontend/ereol_frontend.pages_default.inc
@@ -588,7 +588,21 @@ search/ting
     $pane->type = 'page_tabs';
     $pane->subtype = 'page_tabs';
     $pane->shown = TRUE;
-    $pane->access = array();
+    $pane->access = array(
+      'plugins' => array(
+        0 => array(
+          'name' => 'path_visibility',
+          'settings' => array(
+            'visibility_setting' => '0',
+            'paths' => 'user
+user/*
+',
+          ),
+          'context' => 'argument_string_1',
+          'not' => FALSE,
+        ),
+      ),
+    );
     $pane->configuration = array(
       'type' => 'both',
       'id' => 'tabs',


### PR DESCRIPTION
#### Link to ticket

https://jira.itkdev.dk/browse/ER-1083

#### Description

Hides page tabs on user pages.

#### Screenshot of the result

Before:

<img width="1087" alt="Screenshot 2022-09-13 at 19 44 08" src="https://user-images.githubusercontent.com/11267554/189973624-391d133f-8640-4e26-90fa-88b75490ecec.png">

After:

<img width="1087" alt="Screenshot 2022-09-13 at 19 43 32" src="https://user-images.githubusercontent.com/11267554/189973636-9972de98-c64c-4568-b714-56fc91c5003f.png">

