### PR TITLE
1166: Fixed code

### DIFF
--- a/ereolen_support/ereolen_support.helper.inc
+++ b/ereolen_support/ereolen_support.helper.inc
@@ -334,8 +334,12 @@ function _ereolen_support_support_id_validate(array $element, array $form_state)
  *   The name of the library.
  */
 function _ereolen_support_get_library(): string {
-  if (user_is_logged_in()) {
-    return publizon_get_library($_SESSION['ding_user']['user']['data']['retailer_id'])->library_name;
+  if (user_is_logged_in()
+    && $retailerId = ($_SESSION['ding_user']['user']['data']['retailer_id'] ?? NULL)) {
+    $library = publizon_get_library($retailerId);
+    if ($library instanceof PublizonConfiguredLibrary) {
+      return $library->library_name;
+    }
   }
   return '_none';
 }


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/#/tickets/showTicket/1166


#### Description

Fixes 

> TypeError: Return value of _ereolen_support_get_library() must be of the type string, null returned i _ereolen_support_get_library() (linje 338 af /app/sites/all/modules/ereol/ereolen_support/ereolen_support.helper.inc).

generated when admin user accesses `/support-formular`.

